### PR TITLE
lv_test_timer: stop shadowing the multimer.auto import

### DIFF
--- a/lib/examples/lv_test_timer.py
+++ b/lib/examples/lv_test_timer.py
@@ -124,12 +124,12 @@ def _lvgl_label():
 
 
 def _timer_type():
-    try:
-        timer = getattr(app, "_timer", None)
-        if timer is not None:
-            return _format_timer_type(type(timer))
-    except AttributeError:
-        pass
+    # Deliberately not named ``timer``: that would shadow the module-level
+    # ``multimer.auto`` import this function falls back to, and the fallback
+    # then reads None on any provider that has not armed yet.
+    armed = getattr(app, "_timer", None)
+    if armed is not None:
+        return _format_timer_type(type(armed))
     try:
         from multimer import AsyncTimer
 


### PR DESCRIPTION
`_timer_type()` bound its local to `timer`, the same name as the module-level `from multimer import auto as timer`, so the fallback branch evaluated `None.Timer` whenever `app._timer` was not yet armed. Latent on any provider that defers arming — it surfaced on CircuitPython alongside PyDevices/pydevices#15, but the shadowing is a bug independent of that regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)